### PR TITLE
chore: librarian release pull request: 20250929T113610Z

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,5 +1,0 @@
-handleGHRelease: true
-manifest: true
-manifestFile: v2/.release-please-manifest.json
-manifestConfig: v2/release-please-config.json
-releaseType: go-yoshi

--- a/.github/release-trigger.yml
+++ b/.github/release-trigger.yml
@@ -1,2 +1,0 @@
-enabled: true
-multiScmName: gax-go

--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -1,0 +1,8 @@
+# Hand-maintained configuration for libraries.
+#
+# All libraries with handwritten code (core, hybrid and handwritten)
+# libraries have "release_blocked: true" so that releases are
+# explicitly initiated
+libraries:
+  - id: "v2"
+    release_blocked: true

--- a/.librarian/generator-input/repo-config.yaml
+++ b/.librarian/generator-input/repo-config.yaml
@@ -1,0 +1,1 @@
+# No config required

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,11 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go:latest
 libraries:
   - id: gax
-    version: 2.15.0
+    version: 2.16.0
+    last_generated_commit: ""
+    apis: []
     source_roots:
-      - 'v2'
-    tag_format: 'v{version}'
+      - v2
+    preserve_regex: []
+    remove_regex: []
+    tag_format: v{version}

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,0 +1,7 @@
+image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go:latest
+libraries:
+  - id: gax
+    version: 2.15.0
+    source_roots:
+      - 'v2'
+    tag_format: 'v{version}'

--- a/go.work.sum
+++ b/go.work.sum
@@ -1166,6 +1166,7 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20250428153025-10db94c68c34/go.
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250512202823-5a2f75b736a9/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250519155744-55703ea1f237/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250811230008-5f3141c8851a/go.mod h1:gw1tLEfykwDz2ET4a12jcXt4couGAm7IwsVaTy0Sflo=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20250818200422-3122310a409c/go.mod h1:gw1tLEfykwDz2ET4a12jcXt4couGAm7IwsVaTy0Sflo=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=

--- a/v2/gax.go
+++ b/v2/gax.go
@@ -38,4 +38,5 @@ package gax
 import "github.com/googleapis/gax-go/v2/internal"
 
 // Version specifies the gax-go version being used.
+// This is a test change.
 const Version = internal.Version


### PR DESCRIPTION
Librarian Version: v0.1.1-0.20250929090506-72e18bcf722f
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go:latest
<details><summary>gax: 2.16.0</summary>

## [2.16.0](https://github.com/jskeet/gax-go/compare/v2.15.0...v2.16.0) (2025-09-29)

### Features

* this is a test change ([98b8b91](https://github.com/jskeet/gax-go/commit/98b8b91))

</details>